### PR TITLE
better GitHub button that won't interfere with plugins

### DIFF
--- a/src/public/index.ejs
+++ b/src/public/index.ejs
@@ -3,7 +3,6 @@
 <head prefix="og: https://ogp.me/ns#">
     <%- include('snippets/head.ejs'); %>
     <link href="assets/custom/css/index.css" rel="stylesheet">
-    <script async defer src="https://buttons.github.io/buttons.js"></script>
 </head>
 <body>
 
@@ -13,10 +12,7 @@
             <a href="/" class="text-body-emphasis text-decoration-none">
                 <span class="fs-4">WaifuVault</span>
             </a>
-            <a class="github-button" href="https://github.com/VictoriqueMoe/WaifuVault"
-               data-color-scheme="no-preference: dark; light: light; dark: dark;"
-               data-size="large"
-               aria-label="Star VictoriqueMoe/WaifuVault on GitHub">Source</a>
+            <a class="btn btn-secondary" href="https://github.com/VictoriqueMoe/WaifuVault" target="_blank"><i class="bi bi-github"></i> Source</a>
         </header>
 
         <div class="p-5 mb-4 bg-body-tertiary rounded-3 border border-primary-subtle position-relative">


### PR DESCRIPTION
in https://github.com/VictoriqueMoe/WaifuVault/issues/18 there was an issue where GH buttons was causing dashlane to think it was some input. 

i have changed this to a standard button now 
![image](https://github.com/VictoriqueMoe/WaifuVault/assets/27996712/01f4a601-8597-4c0b-8c7b-52acab8ff383)
