### PR TITLE
better extension handling

### DIFF
--- a/src/engine/FileEngine.ts
+++ b/src/engine/FileEngine.ts
@@ -52,4 +52,13 @@ export class FileEngine {
         return typeof file === "string" ? `${filesDir}/${file}` : file.path;
     }
 
+    public async fileExists(file: string): Promise<boolean> {
+        try {
+            await fs.access(file, fs.constants.F_OK);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
 }


### PR DESCRIPTION
for some reason, in live (not locally), a failed resource from the legacy mode resorts in an internal server error (even though it's returning a 404). this should fix this issue