### PR TITLE
change cors settings

### DIFF
--- a/src/Server.ts
+++ b/src/Server.ts
@@ -105,6 +105,9 @@ const opts: Partial<TsED.Configuration> = {
     middlewares: [
         helmet({
             contentSecurityPolicy: false,
+            crossOriginResourcePolicy: {
+                policy: "cross-origin"
+            },
             crossOriginEmbedderPolicy: {
                 policy: "credentialless"
             }


### PR DESCRIPTION
In order to support embedding resources, we need to allow cors cross-origin. 