### PR TITLE
Fix mobile download of protected files

### DIFF
--- a/src/public/fileLogin.ejs
+++ b/src/public/fileLogin.ejs
@@ -63,7 +63,8 @@
                 }
                 const blob = await response.blob();
                 const _url = window.URL.createObjectURL(blob);
-                if (blob.type === "application/octet-stream") {
+                const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+                if (blob.type === "application/octet-stream" || isSafari) {
                     const a = document.createElement("a");
                     document.body.appendChild(a);
                     a.style.display = "none";
@@ -73,7 +74,7 @@
                     window.URL.revokeObjectURL(_url);
                     a.remove();
                 } else {
-                    window.location = _url;
+                    window.open(_url, "_blank").focus();
                 }
             } catch (err) {
                 console.log(err);

--- a/src/public/fileLogin.ejs
+++ b/src/public/fileLogin.ejs
@@ -16,7 +16,6 @@
                 </div>
                 <div class="card-body">
                     <div class="p-lg-3">
-                        <div class="alert alert-warning mt-4">Ensure popups are allowed in order to view this content</div>
                         <div class="mb-3">
                             <div class="form-floating">
                                 <input required name="password" type="password" class="form-control" id="floatingPassword" placeholder="Password">
@@ -74,7 +73,7 @@
                     window.URL.revokeObjectURL(_url);
                     a.remove();
                 } else {
-                    window.open(_url, "_blank").focus();
+                    window.location = _url;
                 }
             } catch (err) {
                 console.log(err);


### PR DESCRIPTION
Simply using the current window object works for mobile download.  Don't see any difference in functionality over trying to open a popup.