### PR TITLE
Turn mangle off to fix name collision in JS

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -6,7 +6,7 @@
       "compress": {
         "unused": true
       },
-      "mangle": true
+      "mangle": false
     },
     "target": "es2021",
     "parser": {

--- a/.swcrc
+++ b/.swcrc
@@ -6,7 +6,9 @@
       "compress": {
         "unused": true
       },
-      "mangle": false
+      "mangle": {
+        "topLevel": false
+      }
     },
     "target": "es2021",
     "parser": {


### PR DESCRIPTION
Mangle is breaking production JS with a name collision