### PR TITLE
Fix salt being stored in memory only

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ Required Settings
 
 > **Google V2 Recaptcha** is required for the admin login page.  Use non invisible one.
 
-> **SALT ISSUES - IMPORTANT - PLEASE READ** <br>If you have password protected files already before setting this, you
-> will no longer be able to access them afterwards.<br>
+> **SALT ISSUES - IMPORTANT - PLEASE READ** <br>
 > If you change the salt setting after password protected files have been added, you will no longer be able to access
 > the files encrypted with the older salt.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Required Settings
 
 > **Google V2 Recaptcha** is required for the admin login page.  Use non invisible one.
 
+> **SALT ISSUES - IMPORTANT - PLEASE READ** <br>If you have password protected files already before setting this, you
+> will no longer be able to access them afterwards.<br>
+> If you change the salt setting after password protected files have been added, you will no longer be able to access
+> the files encrypted with the older salt.
+
 Optional Settings
 
 | Setting          | Description                                         |

--- a/README.md
+++ b/README.md
@@ -16,14 +16,15 @@ close to the maximum time.  Beyond that, the time allotted drops off sharply, wi
 ### Env file settings
 Required Settings
 
-| Setting                   | Description                                                                 |
-|---------------------------|-----------------------------------------------------------------------------|
-| BLOCKED_MIME_TYPES        | Comma seperated list of MIME types that will be blocked from being uploaded |
-| FILE_SIZE_UPLOAD_LIMIT_MB | Limit on size of file allowed to be uploaded                                |
-| MAX_URL_LENGTH            | Maximum URL length that can be specified                                    |
-| RECAPTCHA_SITE_KEY        | Replace this with your Google V2 Recaptcha Site Key                         |
-| RECAPTCHA_SECRET_KEY      | Replace this with your Google V2 Recaptcha Secret Key                       |
-| SESSION_KEY               | Replace 'YourSessionKey' with a random string to use as the session key     |
+| Setting                   | Description                                                                   |
+|---------------------------|-------------------------------------------------------------------------------|
+| BLOCKED_MIME_TYPES        | Comma seperated list of MIME types that will be blocked from being uploaded   |
+| FILE_SIZE_UPLOAD_LIMIT_MB | Limit on size of file allowed to be uploaded                                  |
+| MAX_URL_LENGTH            | Maximum URL length that can be specified                                      |
+| RECAPTCHA_SITE_KEY        | Replace this with your Google V2 Recaptcha Site Key                           |
+| RECAPTCHA_SECRET_KEY      | Replace this with your Google V2 Recaptcha Secret Key                         |
+| SALT                      | 8 Characters defining salt for encryption (if not set encryption is disabled) |
+| SESSION_KEY               | Replace 'YourSessionKey' with a random string to use as the session key       |
 > **Note Well** the file size sets the time to live for a file, so files close to the upload limit will only be hosted for 30 days.  It is a cubic curve so files up to 50% of the size will get close to a year of hosting time.
 
 > **Google V2 Recaptcha** is required for the admin login page.  Use non invisible one.

--- a/src/controllers/serve/FileServerController.ts
+++ b/src/controllers/serve/FileServerController.ts
@@ -38,7 +38,8 @@ export class FileServerController {
         resource = Path.parse(resource).name;
         const resourceIsProtected = await this.isFilePasswordProtected(resource);
         if (resourceIsProtected && !password) {
-            throw new FileProtectedException("This file requires `x-password` to be set and correct", resource);
+            const isEncrypted = await this.fileService.isFileEncrypted(resource);
+            throw new FileProtectedException("This file requires `x-password` to be set and correct", isEncrypted);
         }
         return resourceIsProtected;
     }

--- a/src/db/repo/FileRepo.ts
+++ b/src/db/repo/FileRepo.ts
@@ -35,7 +35,7 @@ export class FileRepo {
         return this.fileDao.getAllEntriesForIp(ip);
     }
 
-    public getAllEntriesOrdered(start:number, records:number, sortColumn?: string, sortDir?: string, search?: string): Promise<FileUploadModel[]> {
+    public getAllEntriesOrdered(start: number, records: number, sortColumn?: string, sortDir?: string, search?: string): Promise<FileUploadModel[]> {
         return this.fileDao.getAllEntriesOrdered(start, records, sortColumn, sortDir, search);
     }
 

--- a/src/engine/impl/HttpErrorRenderers/FileProtectedRenderEngine.ts
+++ b/src/engine/impl/HttpErrorRenderers/FileProtectedRenderEngine.ts
@@ -20,10 +20,10 @@ export class FileProtectedRenderEngine implements IHttpErrorRenderEngine<string,
     }
 
     public render(obj: HttpErrorRenderObj<FileProtectedException>, response: PlatformResponse): Promise<string> {
-        const resource = obj.internalError.resource;
+        const isEncrypted = obj.internalError.isEncrypted;
         return response.render("fileLogin.ejs", {
             ...obj,
-            resource
+            isEncrypted
         });
     }
 }

--- a/src/migrations/1708885727396-modify_fileUploaddModel_add_encrpted_status.ts
+++ b/src/migrations/1708885727396-modify_fileUploaddModel_add_encrpted_status.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ModifyFileUploaddModelAddEncrptedStatus1708885727396 implements MigrationInterface {
+    name = 'ModifyFileUploaddModelAddEncrptedStatus1708885727396'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "IDX_c8524f9ddc7a24cbae2013fe97"`);
+        await queryRunner.query(`CREATE TABLE "temporary_file_upload_model" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), "fileName" text NOT NULL, "token" text NOT NULL, "checksum" text NOT NULL, "ip" text NOT NULL, "fileSize" integer NOT NULL, "expires" integer NOT NULL, "originalFileName" text NOT NULL DEFAULT (''), "fileExtension" text, "settings" text, "mediaType" text, "encrypted" boolean NOT NULL DEFAULT (0))`);
+        await queryRunner.query(`INSERT INTO "temporary_file_upload_model"("id", "createdAt", "updatedAt", "fileName", "token", "checksum", "ip", "fileSize", "expires", "originalFileName", "fileExtension", "settings", "mediaType") SELECT "id", "createdAt", "updatedAt", "fileName", "token", "checksum", "ip", "fileSize", "expires", "originalFileName", "fileExtension", "settings", "mediaType" FROM "file_upload_model"`);
+        await queryRunner.query(`DROP TABLE "file_upload_model"`);
+        await queryRunner.query(`ALTER TABLE "temporary_file_upload_model" RENAME TO "file_upload_model"`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_c8524f9ddc7a24cbae2013fe97" ON "file_upload_model" ("token") `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "IDX_c8524f9ddc7a24cbae2013fe97"`);
+        await queryRunner.query(`ALTER TABLE "file_upload_model" RENAME TO "temporary_file_upload_model"`);
+        await queryRunner.query(`CREATE TABLE "file_upload_model" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), "fileName" text NOT NULL, "token" text NOT NULL, "checksum" text NOT NULL, "ip" text NOT NULL, "fileSize" integer NOT NULL, "expires" integer NOT NULL, "originalFileName" text NOT NULL DEFAULT (''), "fileExtension" text, "settings" text, "mediaType" text)`);
+        await queryRunner.query(`INSERT INTO "file_upload_model"("id", "createdAt", "updatedAt", "fileName", "token", "checksum", "ip", "fileSize", "expires", "originalFileName", "fileExtension", "settings", "mediaType") SELECT "id", "createdAt", "updatedAt", "fileName", "token", "checksum", "ip", "fileSize", "expires", "originalFileName", "fileExtension", "settings", "mediaType" FROM "temporary_file_upload_model"`);
+        await queryRunner.query(`DROP TABLE "temporary_file_upload_model"`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_c8524f9ddc7a24cbae2013fe97" ON "file_upload_model" ("token") `);
+    }
+
+}

--- a/src/model/constants/GlobalEnv.ts
+++ b/src/model/constants/GlobalEnv.ts
@@ -18,7 +18,8 @@ enum GlobalEnv {
     MS_DEFENDER_PATH = `${prefix}MS_DEFENDER_PATH`,
     RECAPTCHA_SITE_KEY = `${prefix}RECAPTCHA_SITE_KEY`,
     RECAPTCHA_SECRET_KEY = `${prefix}RECAPTCHA_SECRET_KEY`,
-    FILE_CLEANER_CRON = `${prefix}FILE_CLEANER_CRON`
+    FILE_CLEANER_CRON = `${prefix}FILE_CLEANER_CRON`,
+    SALT = `${prefix}SALT`
 }
 
 export default GlobalEnv;

--- a/src/model/db/FileUpload.model.ts
+++ b/src/model/db/FileUpload.model.ts
@@ -80,6 +80,14 @@ export class FileUploadModel extends AbstractModel {
     })
     public mediaType: string | null;
 
+
+    @Column({
+        nullable: false,
+        unique: false,
+        default: false
+    })
+    public encrypted: boolean;
+
     public get expiresIn(): number {
         return FileUtils.getTImeLeft(this);
     }

--- a/src/model/exceptions/FileProtectedException.ts
+++ b/src/model/exceptions/FileProtectedException.ts
@@ -1,7 +1,7 @@
 import {Forbidden} from "@tsed/exceptions";
 
 export class FileProtectedException extends Forbidden {
-    public constructor(message: string, public readonly resource: string, origin?: Error | string) {
+    public constructor(message: string, public readonly isEncrypted: boolean, origin?: Error | string) {
         super(message, origin);
     }
 }

--- a/src/public/fileLogin.ejs
+++ b/src/public/fileLogin.ejs
@@ -2,9 +2,6 @@
 <html lang="en" data-bs-theme="dark">
 <head>
     <%- include('snippets/head.ejs'); %>
-    <% if(!resource){ %>
-        <meta http-equiv="refresh" content="0; URL=/"/>
-    <% } %>
 </head>
 <body>
 <div class="container">
@@ -12,7 +9,7 @@
         <div class="col-md-6 offset-md-3">
             <div class="card my-5 border-primary">
                 <div class="card-header text-center">
-                    Encrypted file
+                    <%- isEncrypted ? "Encrypted file" : "Password-protected file" -%>
                 </div>
                 <div class="card-body">
                     <div class="p-lg-3">

--- a/src/public/index.ejs
+++ b/src/public/index.ejs
@@ -487,7 +487,7 @@ public class Example {
         if (fileSize > fileSizeLimit) {
             toggleShow(badFileSize, true);
             toggleShow(okFileSize, false);
-            return
+            return;
         }
         okFileSize.innerText = timeToHuman(getTimeLeftBySize(file.size));
         toggleShow(badFileSize, false);

--- a/src/public/secure/admin.ejs
+++ b/src/public/secure/admin.ejs
@@ -173,7 +173,7 @@
                         return sizedData;
                     }
                     return data;
-                }
+                };
             }
 
             function customDate() {
@@ -182,7 +182,7 @@
                         return new Date(Date.parse(data)).toLocaleString();
                     }
                     return data;
-                }
+                };
             }
 
             function getDataMapping(type) {
@@ -285,7 +285,7 @@
             }
 
             function getButtons(type) {
-                const buttons = []
+                const buttons = [];
                 if (type === "entries") {
                     buttons.push({
                             extend: 'selected',
@@ -351,7 +351,7 @@
                                 const url = selectedRow.url;
                                 window.open(url, "_blank");
                             }
-                        })
+                        });
                 } else if (type === "ips") {
                     buttons.push({
                         extend: 'selected',
@@ -371,7 +371,7 @@
                             dt.rows({selected: true}).remove().draw(false);
                             reloadTable(["entries"]);
                         }
-                    })
+                    });
                 }
                 return buttons;
             }
@@ -399,7 +399,7 @@
                                 .rows(indexes)
                                 .data()
                                 .pluck('ipBanned');
-                            disableButtonsOnSelection(data.get(0), table.buttons(['#banIpButton']))
+                            disableButtonsOnSelection(data.get(0), table.buttons(['#banIpButton']));
                         }
                     });
                 }

--- a/src/services/FileService.ts
+++ b/src/services/FileService.ts
@@ -86,7 +86,8 @@ export class FileService {
 
         if (password) {
             try {
-                await this.encryptionService.encrypt(resourcePath, password);
+                const didEncrypt = await this.encryptionService.encrypt(resourcePath, password);
+                uploadEntry.encrypted(didEncrypt);
             } catch (e) {
                 await this.deleteUploadedFile(resourcePath);
                 this.logger.error(e.message);
@@ -138,6 +139,14 @@ export class FileService {
             retObj["hideFilename"] = hideFilename;
         }
         return Object.keys(retObj).length === 0 ? null : retObj;
+    }
+
+    public async isFileEncrypted(resource: string): Promise<boolean> {
+        const entry = await this.repo.getEntryFileName(resource);
+        if (!entry) {
+            return false;
+        }
+        return entry.encrypted;
     }
 
     public async requiresPassword(resource: string): Promise<boolean> {

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -4,8 +4,6 @@ import type {FileUploadModel} from "../model/db/FileUpload.model.js";
 import TIME_UNIT from "../model/constants/TIME_UNIT.js";
 import process from "process";
 import type {Request} from "express";
-import * as os from "os";
-import fs from "node:fs";
 
 export class ObjectUtils {
 

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -117,7 +117,7 @@ export class FileUtils {
     }
 
     public static setEnvValue(key:string, value:string) {
-        const envVars = FileUtils.readEnvFile(`${filesDir}/../.env`);
+        const envVars = FileUtils.readEnvFile(`${baseDir}/.env`);
         const targetLine = envVars.find((line) => line.split("=")[0] === key);
         if (targetLine !== undefined) {
             const targetLineIndex = envVars.indexOf(targetLine);

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -4,6 +4,8 @@ import type {FileUploadModel} from "../model/db/FileUpload.model.js";
 import TIME_UNIT from "../model/constants/TIME_UNIT.js";
 import process from "process";
 import type {Request} from "express";
+import * as os from "os";
+import fs from "node:fs";
 
 export class ObjectUtils {
 
@@ -104,6 +106,27 @@ export class FileUtils {
     public static isFileCustomExpire(entry: FileUploadModel): boolean {
         return FileUtils.getExpiresBySize(entry.fileSize) != entry.expires - entry.createdAt.getTime();
     }
+
+    public static readEnvFile(envfilepath:string): string[] {
+        return fs.readFileSync(envfilepath,'utf-8').split(os.EOL);
+    }
+
+    public static getEnvValue(key:string): string|null {
+        const matchedLine = FileUtils.readEnvFile(`${baseDir}/.env`).find((line:string) => line.split("=")[0] === key);
+        return matchedLine !== undefined ? matchedLine.split("=")[1] : null;
+    }
+
+    public static setEnvValue(key:string, value:string) {
+        const envVars = FileUtils.readEnvFile(`${filesDir}/../.env`);
+        const targetLine = envVars.find((line) => line.split("=")[0] === key);
+        if (targetLine !== undefined) {
+            const targetLineIndex = envVars.indexOf(targetLine);
+            envVars.splice(targetLineIndex, 1, `${key}="${value}"`);
+        } else {
+            envVars.push(`${key}="${value}"`);
+        }
+        fs.writeFileSync(`${baseDir}/.env`, envVars.join(os.EOL));
+    }
 }
 
 export class NetworkUtils {
@@ -132,3 +155,4 @@ export class NetworkUtils {
 }
 
 export const filesDir = `${path.dirname(fileURLToPath(import.meta.url))}/../../files`;
+export const baseDir = `${path.dirname(fileURLToPath(import.meta.url))}/../..`;

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -106,27 +106,6 @@ export class FileUtils {
     public static isFileCustomExpire(entry: FileUploadModel): boolean {
         return FileUtils.getExpiresBySize(entry.fileSize) != entry.expires - entry.createdAt.getTime();
     }
-
-    public static readEnvFile(envfilepath:string): string[] {
-        return fs.readFileSync(envfilepath,'utf-8').split(os.EOL);
-    }
-
-    public static getEnvValue(key:string): string|null {
-        const matchedLine = FileUtils.readEnvFile(`${baseDir}/.env`).find((line:string) => line.split("=")[0] === key);
-        return matchedLine !== undefined ? matchedLine.split("=")[1] : null;
-    }
-
-    public static setEnvValue(key:string, value:string) {
-        const envVars = FileUtils.readEnvFile(`${baseDir}/.env`);
-        const targetLine = envVars.find((line) => line.split("=")[0] === key);
-        if (targetLine !== undefined) {
-            const targetLineIndex = envVars.indexOf(targetLine);
-            envVars.splice(targetLineIndex, 1, `${key}="${value}"`);
-        } else {
-            envVars.push(`${key}="${value}"`);
-        }
-        fs.writeFileSync(`${baseDir}/.env`, envVars.join(os.EOL));
-    }
 }
 
 export class NetworkUtils {
@@ -155,4 +134,3 @@ export class NetworkUtils {
 }
 
 export const filesDir = `${path.dirname(fileURLToPath(import.meta.url))}/../../files`;
-export const baseDir = `${path.dirname(fileURLToPath(import.meta.url))}/../..`;


### PR DESCRIPTION
Added methods to FileUtils to allow writing env vars back to .env.

Added onInit to the Encryption service that checks for SALT env variable being set.  If it is not then it generates a random salt value, and writes it to the environment.

I tested by storing an encrypted file, then stopping and starting the server, and verifying it could still be downloaded correctly (which it could - was image so easy to see it working).

I performed a negative test also.  I stopped the server, and deleted the SALT line in the .env.  At boot, verified it put a new different salt.  And finally verified that the previously encrypted file did not download correctly as it was not decrypted properly.