### PR TITLE
remove lint command from build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "npx eslint .",
     "lint:fix": "npx eslint --fix .",
     "tsc": "tsc --project tsconfig.compile.json",
-    "build": "npm run lint && npm run barrels && node ./buildScripts/cleanDist.mjs && npx swc src -d dist --config-file .swcrc --copy-files && node ./buildScripts/moveFiles.mjs",
+    "build": "npm run barrels && node ./buildScripts/cleanDist.mjs && npx swc src -d dist --config-file .swcrc --copy-files && node ./buildScripts/moveFiles.mjs",
     "barrels": "barrelsby --config .barrelsby.json && node ./buildScripts/fixbarrels.cjs",
     "start_js": "node dist/index.js",
     "start": "node --loader ts-node/esm src/index.ts",


### PR DESCRIPTION
the lint command no longer needs to be part of the build, these are pre-build hooks that are run externally 